### PR TITLE
Fix fstring

### DIFF
--- a/src/clearskies/column_types/many_to_many.py
+++ b/src/clearskies/column_types/many_to_many.py
@@ -199,7 +199,7 @@ class ManyToMany(String):
             pivot_models = self.pivot_models
             foreign_column_name = self.config("foreign_column_name_in_pivot")
             for model_to_delete in pivot_models.where(
-                f"{foreign_column_name} IN (" + ",".join(map(str, to_delete)) + ")"
+                f"{foreign_column_name} IN ({",".join(map(str, to_delete))})"
             ):
                 model_to_delete.delete()
         if to_create:


### PR DESCRIPTION
Try to fix: 

```python
[ERROR] NameError: name 'join' is not defined
Traceback (most recent call last):
 <redacted>
  File "/var/task/clearskies/model.py", line 123, in save
    data = self.columns_post_save(data, id, columns)
  File "/var/task/clearskies/model.py", line 180, in columns_post_save
    data = column.post_save(data, self, id)
  File "/var/task/clearskies/column_types/many_to_many.py", line 156, in post_save
    for model_to_delete in related_models.where("id IN (" + join(',', map(str, to_delete)) + ")"):
```