### PR TITLE
Fix __call__ to return object

### DIFF
--- a/src/clearskies/authentication/public.py
+++ b/src/clearskies/authentication/public.py
@@ -37,4 +37,4 @@ class PublicAuth(AuthBase, Public):
 
     def __call__(self, r: PreparedRequest) -> PreparedRequest:
         r.headers = {**r.headers, **self.headers()}
-        return super().__call__(r)
+        return r

--- a/src/clearskies/authentication/secret_bearer.py
+++ b/src/clearskies/authentication/secret_bearer.py
@@ -88,4 +88,4 @@ class SecretBearerAuth(AuthBase, SecretBearer):
 
     def __call__(self, r: PreparedRequest) -> PreparedRequest:
         r.headers = {**r.headers, **self.headers()}
-        return super().__call__(r)
+        return r


### PR DESCRIPTION
If super is used, it will raise error not implemented